### PR TITLE
Expand feed API and add paginated post list with reactions

### DIFF
--- a/src/app/(routes)/feed/page.tsx
+++ b/src/app/(routes)/feed/page.tsx
@@ -1,10 +1,17 @@
+"use client"
+
 import { t } from '../../../lib/i18n'
+import { useSearchParams } from 'next/navigation'
+import PostList from '../../../components/post-list'
 
 export default function FeedPage() {
+  const params = useSearchParams()
+  const userId = params.get('user') ?? ''
+
   return (
     <div>
       <h1>{t('feed_title', 'off')}</h1>
-      <p>Placeholder Tavern feed.</p>
+      {userId ? <PostList userId={userId} /> : <p>No user.</p>}
     </div>
   )
 }

--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -5,24 +5,48 @@ import { canViewPost } from '../../../lib/acl'
 export async function GET(req: Request) {
   const url = new URL(req.url)
   const userId = url.searchParams.get('user')
+  const page = parseInt(url.searchParams.get('page') ?? '1', 10)
+  const take = parseInt(url.searchParams.get('take') ?? '20', 10)
   if (!userId) return NextResponse.json([])
 
-  const guildIds = (await prisma.guildMembership.findMany({
-    where: { userId, status: 'APPROVED' },
-    select: { guildId: true }
-  })).map(g => g.guildId)
+  const guildIds = (
+    await prisma.guildMembership.findMany({
+      where: { userId, status: 'APPROVED' },
+      select: { guildId: true }
+    })
+  ).map(g => g.guildId)
 
-  const friendIds = (await prisma.relationship.findMany({
-    where: { followerId: userId, type: 'FRIEND', status: 'ACCEPTED' },
-    select: { followeeId: true }
-  })).map(r => r.followeeId)
+  const friendIds = (
+    await prisma.relationship.findMany({
+      where: { followerId: userId, type: 'FRIEND', status: 'ACCEPTED' },
+      select: { followeeId: true }
+    })
+  ).map(r => r.followeeId)
+
+  const followeeIds = (
+    await prisma.relationship.findMany({
+      where: { followerId: userId, type: 'FOLLOW', status: 'ACCEPTED' },
+      select: { followeeId: true }
+    })
+  ).map(r => r.followeeId)
+
+  const authorIds = [userId, ...friendIds, ...followeeIds]
 
   const posts = await prisma.post.findMany({
+    where: {
+      OR: [
+        { authorId: { in: authorIds } },
+        { guildId: { in: guildIds } }
+      ]
+    },
     orderBy: { createdAt: 'desc' },
-    take: 20,
+    skip: (page - 1) * take,
+    take,
     include: { guild: true }
   })
 
-  const visible = posts.filter(p => canViewPost({ viewerId: userId, post: p, viewerGuildIds: guildIds, friendIds }))
+  const visible = posts.filter(p =>
+    canViewPost({ viewerId: userId, post: p, viewerGuildIds: guildIds, friendIds })
+  )
   return NextResponse.json(visible)
 }

--- a/src/components/post-list.tsx
+++ b/src/components/post-list.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface Post {
+  id: string
+  body: string
+  guild?: { name: string } | null
+}
+
+interface PostListProps {
+  userId: string
+}
+
+export default function PostList({ userId }: PostListProps) {
+  const [posts, setPosts] = useState<Post[]>([])
+  const [page, setPage] = useState(1)
+  const [loading, setLoading] = useState(false)
+  const [hasMore, setHasMore] = useState(true)
+
+  useEffect(() => {
+    const fetchPosts = async () => {
+      setLoading(true)
+      const res = await fetch(`/api/feed?user=${userId}&page=${page}`)
+      const data = await res.json()
+      if (data.length === 0) {
+        setHasMore(false)
+      } else {
+        setPosts(prev => [...prev, ...data])
+      }
+      setLoading(false)
+    }
+    fetchPosts()
+  }, [page, userId])
+
+  const loadMore = () => {
+    if (!loading && hasMore) setPage(p => p + 1)
+  }
+
+  const likePost = async (postId: string) => {
+    await fetch(`/api/posts/${postId}/react`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId, type: 'LIKE' })
+    })
+  }
+
+  const commentOnPost = async (postId: string) => {
+    const body = prompt('Enter comment')
+    if (!body) return
+    await fetch(`/api/posts/${postId}/comment`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ authorId: userId, body })
+    })
+  }
+
+  return (
+    <div>
+      {posts.map(post => (
+        <div key={post.id} className="border p-4 mb-2">
+          <p>{post.body}</p>
+          {post.guild && <p className="text-sm text-gray-500">Guild: {post.guild.name}</p>}
+          <div className="mt-2 flex gap-2">
+            <button onClick={() => likePost(post.id)}>Like</button>
+            <button onClick={() => commentOnPost(post.id)}>Comment</button>
+          </div>
+        </div>
+      ))}
+      {hasMore && (
+        <button disabled={loading} onClick={loadMore} className="mt-4">
+          {loading ? 'Loading...' : 'Load More'}
+        </button>
+      )}
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- extend feed API to include followees alongside friends and guild posts with pagination support
- show paginated feed using new PostList component on the feed page
- wire up like and comment actions to their respective API endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a67a832470832b85b3e73749569cad