### PR TITLE
Secure search results based on viewer permissions

### DIFF
--- a/src/app/(routes)/search/page.tsx
+++ b/src/app/(routes)/search/page.tsx
@@ -3,7 +3,7 @@ import { t } from '../../../lib/i18n'
 export default function SearchPage() {
   return (
     <div>
-      <h1>{t('map', 'off') ?? 'Search'}</h1>
+      <h1>{t('search', 'off') ?? 'Search'}</h1>
       <p>Search placeholder.</p>
     </div>
   )

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,18 +1,47 @@
 import { NextResponse } from 'next/server'
 import prisma from '../../../lib/db'
+import { filterVisiblePosts, filterVisibleGuilds } from '../../../lib/search'
 
 export async function GET(req: Request) {
   const url = new URL(req.url)
   const q = url.searchParams.get('q') || ''
   const type = url.searchParams.get('type') || 'people'
+  const viewerId = url.searchParams.get('user') || ''
+
   if (type === 'people') {
     const users = await prisma.user.findMany({ where: { handle: { contains: q } } })
     return NextResponse.json(users)
   } else if (type === 'posts') {
-    const posts = await prisma.post.findMany({ where: { body: { contains: q } } })
-    return NextResponse.json(posts)
+    const posts = await prisma.post.findMany({ where: { body: { contains: q } }, include: { guild: true } })
+
+    let guildIds: string[] = []
+    let friendIds: string[] = []
+    if (viewerId) {
+      guildIds = (await prisma.guildMembership.findMany({
+        where: { userId: viewerId, status: 'APPROVED' },
+        select: { guildId: true }
+      })).map(g => g.guildId)
+
+      friendIds = (await prisma.relationship.findMany({
+        where: { followerId: viewerId, type: 'FRIEND', status: 'ACCEPTED' },
+        select: { followeeId: true }
+      })).map(r => r.followeeId)
+    }
+
+    const visible = filterVisiblePosts({ posts, viewerId, viewerGuildIds: guildIds, friendIds })
+    return NextResponse.json(visible)
   } else {
     const guilds = await prisma.guild.findMany({ where: { name: { contains: q } } })
-    return NextResponse.json(guilds)
+
+    let guildIds: string[] = []
+    if (viewerId) {
+      guildIds = (await prisma.guildMembership.findMany({
+        where: { userId: viewerId, status: 'APPROVED' },
+        select: { guildId: true }
+      })).map(g => g.guildId)
+    }
+
+    const visible = filterVisibleGuilds(guilds, guildIds)
+    return NextResponse.json(visible)
   }
 }

--- a/src/i18n/strings.json
+++ b/src/i18n/strings.json
@@ -9,5 +9,6 @@
   "create_guild": {"off": "Create Group", "subtle": "Draft a Guild Charter (Create Group)", "bold": "Draft a Guild Charter"},
   "post_cta": {"off": "Create Post", "subtle": "Raise a Toast (Create Post)", "bold": "Raise a Toast"},
   "report": {"off": "Report", "subtle": "Call the Town Guard (Report)", "bold": "Call the Town Guard"},
+  "search": {"off": "Search", "subtle": "Scrying Pool (Search)", "bold": "Scrying Pool"},
   "loading": {"off": "Loading…", "subtle": "Rolling for initiative…", "bold": "Rolling for initiative…"}
 }

--- a/src/lib/search.js
+++ b/src/lib/search.js
@@ -1,0 +1,13 @@
+const { canViewPost } = require('./acl.js')
+
+function filterVisiblePosts({ posts, viewerId, viewerGuildIds, friendIds }) {
+  return posts.filter(post =>
+    canViewPost({ viewerId, post, viewerGuildIds, friendIds })
+  )
+}
+
+function filterVisibleGuilds(guilds, viewerGuildIds) {
+  return guilds.filter(g => g.privacy === 'PUBLIC' || viewerGuildIds.includes(g.id))
+}
+
+module.exports = { filterVisiblePosts, filterVisibleGuilds }

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -1,0 +1,18 @@
+import { Guild, Post } from '@prisma/client'
+import { canViewPost } from './acl'
+
+export function filterVisiblePosts(params: {
+  posts: (Post & { guild?: Guild | null })[]
+  viewerId: string
+  viewerGuildIds: string[]
+  friendIds: string[]
+}) {
+  const { posts, viewerId, viewerGuildIds, friendIds } = params
+  return posts.filter(post =>
+    canViewPost({ viewerId, post, viewerGuildIds, friendIds })
+  )
+}
+
+export function filterVisibleGuilds(guilds: Guild[], viewerGuildIds: string[]) {
+  return guilds.filter(g => g.privacy === 'PUBLIC' || viewerGuildIds.includes(g.id))
+}

--- a/tests/search.test.js
+++ b/tests/search.test.js
@@ -1,0 +1,24 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const { filterVisiblePosts, filterVisibleGuilds } = require('../src/lib/search.js')
+
+test('filterVisibleGuilds excludes private guilds for unauthorized user', () => {
+  const guilds = [
+    { id: 'g1', privacy: 'PRIVATE' },
+    { id: 'g2', privacy: 'PUBLIC' }
+  ]
+  const visible = filterVisibleGuilds(guilds, [])
+  assert.equal(visible.length, 1)
+  assert.equal(visible[0].id, 'g2')
+})
+
+test('filterVisiblePosts excludes private posts for unauthorized user', () => {
+  const posts = [
+    { id: 'p1', visibility: 'PUBLIC', scope: 'PROFILE', authorId: 'u1' },
+    { id: 'p2', visibility: 'FRIENDS', scope: 'PROFILE', authorId: 'u2' },
+    { id: 'p3', visibility: 'PUBLIC', scope: 'GUILD', guildId: 'g1', authorId: 'u3', guild: { id: 'g1', privacy: 'PRIVATE' } }
+  ]
+  const visible = filterVisiblePosts({ posts, viewerId: '', viewerGuildIds: [], friendIds: [] })
+  assert.equal(visible.length, 1)
+  assert.equal(visible[0].id, 'p1')
+})


### PR DESCRIPTION
## Summary
- add "search" localization key and use it in search page
- restrict search API results to viewer's accessible posts and guilds
- cover search filtering with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a67a8782b8832b947d72c19bf804e5