### PR TITLE
Restrict guild membership actions to leaders

### DIFF
--- a/src/app/api/guilds/[slug]/approve/route.ts
+++ b/src/app/api/guilds/[slug]/approve/route.ts
@@ -1,8 +1,28 @@
 import { NextResponse } from 'next/server'
 import prisma from '../../../../../lib/db'
+import { canManageGuild } from '../../../../../lib/acl'
 
 export async function POST(req: Request, { params }: { params: { slug: string } }) {
-  const { membershipId } = await req.json()
-  const membership = await prisma.guildMembership.update({ where: { id: membershipId }, data: { status: 'APPROVED' } })
-  return NextResponse.json(membership)
+  const { membershipId, userId } = await req.json()
+
+  const membership = await prisma.guildMembership.findUnique({
+    where: { id: membershipId },
+    include: { guild: true }
+  })
+  if (!membership || membership.guild.slug !== params.slug) {
+    return NextResponse.json({ error: 'not found' }, { status: 404 })
+  }
+
+  const actor = await prisma.guildMembership.findFirst({
+    where: { guildId: membership.guildId, userId }
+  })
+  if (!actor || !canManageGuild(actor.role)) {
+    return NextResponse.json({ error: 'forbidden' }, { status: 403 })
+  }
+
+  const updated = await prisma.guildMembership.update({
+    where: { id: membershipId },
+    data: { status: 'APPROVED' }
+  })
+  return NextResponse.json(updated)
 }

--- a/src/app/api/guilds/[slug]/ban/route.ts
+++ b/src/app/api/guilds/[slug]/ban/route.ts
@@ -1,8 +1,28 @@
 import { NextResponse } from 'next/server'
 import prisma from '../../../../../lib/db'
+import { canManageGuild } from '../../../../../lib/acl'
 
 export async function POST(req: Request, { params }: { params: { slug: string } }) {
-  const { membershipId } = await req.json()
-  const membership = await prisma.guildMembership.update({ where: { id: membershipId }, data: { status: 'BANNED' } })
-  return NextResponse.json(membership)
+  const { membershipId, userId } = await req.json()
+
+  const membership = await prisma.guildMembership.findUnique({
+    where: { id: membershipId },
+    include: { guild: true }
+  })
+  if (!membership || membership.guild.slug !== params.slug) {
+    return NextResponse.json({ error: 'not found' }, { status: 404 })
+  }
+
+  const actor = await prisma.guildMembership.findFirst({
+    where: { guildId: membership.guildId, userId }
+  })
+  if (!actor || !canManageGuild(actor.role)) {
+    return NextResponse.json({ error: 'forbidden' }, { status: 403 })
+  }
+
+  const updated = await prisma.guildMembership.update({
+    where: { id: membershipId },
+    data: { status: 'BANNED' }
+  })
+  return NextResponse.json(updated)
 }

--- a/src/lib/acl.js
+++ b/src/lib/acl.js
@@ -8,4 +8,9 @@ function canViewPost({ viewerId, post, viewerGuildIds, friendIds }) {
   if (post.authorId === viewerId) return true
   return friendIds.includes(post.authorId)
 }
-module.exports = { canViewPost }
+
+function canManageGuild(role) {
+  return role === 'OWNER' || role === 'OFFICER'
+}
+
+module.exports = { canViewPost, canManageGuild }

--- a/tests/guilds.test.js
+++ b/tests/guilds.test.js
@@ -1,0 +1,15 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const { canManageGuild } = require('../src/lib/acl.js')
+
+test('owner can manage guild membership', () => {
+  assert.equal(canManageGuild('OWNER'), true)
+})
+
+test('officer can manage guild membership', () => {
+  assert.equal(canManageGuild('OFFICER'), true)
+})
+
+test('member cannot manage guild membership', () => {
+  assert.equal(canManageGuild('MEMBER'), false)
+})


### PR DESCRIPTION
## Summary
- verify guild owner/officer before approving or banning members
- add `canManageGuild` helper
- test guild role authorization for owner/officer/member

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a67a896218832b9c0d43f539cf1d4c