### PR TITLE
feat: add profile display and editing

### DIFF
--- a/src/app/(routes)/profile/edit/page.tsx
+++ b/src/app/(routes)/profile/edit/page.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useForm } from 'react-hook-form'
+import { useRouter } from 'next/navigation'
+
+interface FormData {
+  displayName: string
+  bio: string
+  avatarUrl: string
+}
+
+export default function EditProfilePage() {
+  const { register, handleSubmit } = useForm<FormData>()
+  const router = useRouter()
+
+  const onSubmit = async (data: FormData) => {
+    await fetch('/api/profiles/me', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    })
+    router.push('/profile')
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <input {...register('displayName')} placeholder="Display Name" />
+      <textarea {...register('bio')} placeholder="Bio" />
+      <input {...register('avatarUrl')} placeholder="Avatar URL" />
+      <button type="submit">Save</button>
+    </form>
+  )
+}

--- a/src/app/(routes)/profile/page.tsx
+++ b/src/app/(routes)/profile/page.tsx
@@ -1,10 +1,32 @@
 import { t } from '../../../lib/i18n'
+import { getSession } from '../../../lib/auth'
+import prisma from '../../../lib/db'
 
-export default function ProfilePage() {
+export default async function ProfilePage() {
+  const session = await getSession()
+  const user = session?.user?.id
+    ? await prisma.user.findUnique({
+        where: { id: session.user.id },
+        include: { posts: true }
+      })
+    : null
+
   return (
     <div>
-      <h1>{t('groups_title', 'off')}</h1>
-      <p>Public profile placeholder.</p>
+      <h1>{t('profile_title', 'off')}</h1>
+      {user && (
+        <div>
+          {user.avatarUrl && (
+            <img src={user.avatarUrl} alt={user.displayName} />
+          )}
+          {user.bio && <p>{user.bio}</p>}
+          <ul>
+            {user.posts.map(post => (
+              <li key={post.id}>{post.body}</li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/app/api/profiles/me/route.ts
+++ b/src/app/api/profiles/me/route.ts
@@ -1,8 +1,28 @@
 import { NextResponse } from 'next/server'
-import prisma from '../../../lib/db'
+import prisma from '../../../../lib/db'
+import { getSession } from '../../../../lib/auth'
+
+export async function GET() {
+  const session = await getSession()
+  if (!session?.user?.id) {
+    return NextResponse.json(null, { status: 401 })
+  }
+  const user = await prisma.user.findUnique({
+    where: { id: session.user.id },
+    include: { posts: true }
+  })
+  return NextResponse.json(user)
+}
 
 export async function PATCH(req: Request) {
+  const session = await getSession()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
   const data = await req.json()
-  const user = await prisma.user.update({ where: { id: data.id }, data })
+  const user = await prisma.user.update({
+    where: { id: session.user.id },
+    data
+  })
   return NextResponse.json(user)
 }

--- a/src/i18n/strings.json
+++ b/src/i18n/strings.json
@@ -4,6 +4,7 @@
   "feed_title": {"off": "Feed", "subtle": "Tavern’s Quest Board (Feed)", "bold": "Tavern’s Quest Board"},
   "groups_title": {"off": "Groups", "subtle": "Guilds (Groups)", "bold": "Guilds"},
   "group_feed": {"off": "Group Feed", "subtle": "Guild Hall (Group Feed)", "bold": "Guild Hall"},
+  "profile_title": {"off": "Profile", "subtle": "Character Sheet (Profile)", "bold": "Character Sheet"},
   "settings": {"off": "Settings", "subtle": "DM Screen (Settings)", "bold": "DM Screen"},
   "help": {"off": "Help", "subtle": "Sage’s Library (Help)", "bold": "Sage’s Library"},
   "create_guild": {"off": "Create Group", "subtle": "Draft a Guild Charter (Create Group)", "bold": "Draft a Guild Charter"},


### PR DESCRIPTION
## Summary
- add profile title translation
- build profile page showing avatar, bio, and posts
- create edit profile form and API for updating own profile

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a67a8ab044832ba8ad9517ddda6a9e